### PR TITLE
Create DB schema to save orders for check out

### DIFF
--- a/webApp/src/main/resources/application.properties
+++ b/webApp/src/main/resources/application.properties
@@ -1,4 +1,14 @@
+logging.level.com.radient=DEBUG
 spring.application.name=webApp
 spring.docker.compose.enabled=false
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+
+spring.liquibase.change-log=classpath:/db.changelog/foodtruck-1.0.xml
+
+spring.datasource.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.hikari.username=root
+spring.datasource.hikari.password=FTS@2024#
+spring.datasource.hikari.jdbcUrl=jdbc:mysql://localhost:3306/foodtruckservice_db
+spring.liquibase.enabled=true
+
 


### PR DESCRIPTION
I can now configure the SQL workbench with Liquibase after setting up Liquibase locally and creating the DB schema for the order table in SQL. 